### PR TITLE
React to text in caption

### DIFF
--- a/v2/parser/handlers.go
+++ b/v2/parser/handlers.go
@@ -103,7 +103,7 @@ func (up *UpdateParser) checkChatSharedHandlers(update *objs.Update) bool {
 }
 
 func (up *UpdateParser) checkTextMsgHandlers(update *objs.Update) bool {
-	if update.Message != nil && update.Message.Text != "" {
+	if update.Message != nil && (update.Message.Text != "" || update.Message.Caption != "") {
 		hndl := up.handlers.GetHandler(update.Message)
 		if hndl != nil {
 			go (*hndl.function)(update)

--- a/v2/parser/tree.go
+++ b/v2/parser/tree.go
@@ -26,7 +26,11 @@ func (tr *handlerTree) AddHandler(hdl *handler) {
 
 // GetHandler gets the proper handler for the given text.
 func (tr *handlerTree) GetHandler(msg *objs.Message) *handler {
-	tn := tr.findTheNodeRegex(msg.Text, msg.Chat.Type)
+	msgText := msg.Text
+	if msg.Caption != "" {
+		msgText = msg.Caption
+	}
+	tn := tr.findTheNodeRegex(msgText, msg.Chat.Type)
 	if tn != nil {
 		return tn.data
 	}

--- a/v2/parser/tree_test.go
+++ b/v2/parser/tree_test.go
@@ -65,5 +65,12 @@ func initTheTable() {
 	test6 := handlerTest{msg: &objects.Message{Text: "hi everyone", Chat: &objects.Chat{Type: "channel"}}, expectedRegex: "hi"}
 	test7 := handlerTest{msg: &objects.Message{Text: "start again", Chat: &objects.Chat{Type: "group"}}, expectedRegex: "start"}
 	test8 := handlerTest{msg: &objects.Message{Text: "start again", Chat: &objects.Chat{Type: "private"}}, expectedRegex: "start again"}
-	testTable = []handlerTest{test1, test2, test3, test4, test5, test6, test7, test8}
+	test9 := handlerTest{msg: &objects.Message{Caption: "hi guys", Chat: &objects.Chat{Type: "group"}}, expectedRegex: "hi"}
+	test10 := handlerTest{msg: &objects.Message{Caption: "start", Chat: &objects.Chat{Type: "group"}}, expectedRegex: "start"}
+	test11 := handlerTest{msg: &objects.Message{Caption: "start bot", Chat: &objects.Chat{Type: "supergroup"}}, expectedRegex: "start bot"}
+	test12 := handlerTest{msg: &objects.Message{Caption: "hi everyone", Chat: &objects.Chat{Type: "group"}}, expectedRegex: "hi everyone"}
+	test13 := handlerTest{msg: &objects.Message{Caption: "hi everyone", Chat: &objects.Chat{Type: "channel"}}, expectedRegex: "hi"}
+	test14 := handlerTest{msg: &objects.Message{Caption: "start again", Chat: &objects.Chat{Type: "group"}}, expectedRegex: "start"}
+	test15 := handlerTest{msg: &objects.Message{Caption: "start again", Chat: &objects.Chat{Type: "private"}}, expectedRegex: "start again"}
+	testTable = []handlerTest{test1, test2, test3, test4, test5, test6, test7, test8, test9, test10, test11, test12, test13, test14, test15}
 }


### PR DESCRIPTION
This PR implements the reaction to bot commands in the caption.
As the codebase was before, it was not running the handlers if the `update.Message.Caption` did contain a bot command.

## What's changed
Now the bots developed with telego will be able to make react their handlers to commands not only in the `update.Message.Text` but also in `update.Message.Caption`.