### PR TITLE
Fix panic

### DIFF
--- a/v2/parser/handlers.go
+++ b/v2/parser/handlers.go
@@ -60,6 +60,10 @@ func (up *UpdateParser) AddChatSharedHandler(requestId int, handler func(*objs.U
 }
 
 func (up *UpdateParser) checkHandlers(update *objs.Update) bool {
+	if update == nil || update.Message == nil {
+		return false
+	}
+
 	if update.CallbackQuery != nil {
 		return up.checkCallbackHanlders(update)
 	}


### PR DESCRIPTION
This PR fixes a panic for which when the bot is started, it had the Message == nil.
I added a check to control that we were not accessing to a fields for a nil value and should fix the issue #21 