### PR TITLE
Fix issue #26: Correct struct tag for one time keyboard

### DIFF
--- a/objects/keyboardObjects.go
+++ b/objects/keyboardObjects.go
@@ -13,7 +13,7 @@ type ReplyKeyboardMarkup struct {
 	/*Optional. Requests clients to resize the keyboard vertically for optimal fit (e.g., make the keyboard smaller if there are just two rows of buttons). Defaults to false, in which case the custom keyboard is always of the same height as the app's standard keyboard.*/
 	ResizeKeyboard bool `json:"resize_keyboard"`
 	/*Optional. Requests clients to hide the keyboard as soon as it's been used. The keyboard will still be available, but clients will automatically display the usual letter-keyboard in the chat – the user can press a special button in the input field to see the custom keyboard again. Defaults to false*/
-	OneTimeKeyboard bool `json:"one_tijme_keyboard"`
+	OneTimeKeyboard bool `json:"one_time_keyboard"`
 	/*Optional. The placeholder to be shown in the input field when the keyboard is active; 1-64 characters*/
 	InputFieldPlaceholder string `json:"input_field_placeholder,omitempty"`
 	/*Optional. Use this parameter if you want to show the keyboard to specific users only. Targets: 1) users that are @mentioned in the text of the Message object; 2) if the bot's message is a reply (has reply_to_message_id), sender of the original message.

--- a/v2/objects/keyboardObjects.go
+++ b/v2/objects/keyboardObjects.go
@@ -13,7 +13,7 @@ type ReplyKeyboardMarkup struct {
 	/*Optional. Requests clients to resize the keyboard vertically for optimal fit (e.g., make the keyboard smaller if there are just two rows of buttons). Defaults to false, in which case the custom keyboard is always of the same height as the app's standard keyboard.*/
 	ResizeKeyboard bool `json:"resize_keyboard"`
 	/*Optional. Requests clients to hide the keyboard as soon as it's been used. The keyboard will still be available, but clients will automatically display the usual letter-keyboard in the chat – the user can press a special button in the input field to see the custom keyboard again. Defaults to false*/
-	OneTimeKeyboard bool `json:"one_tijme_keyboard"`
+	OneTimeKeyboard bool `json:"one_time_keyboard"`
 	/*Optional. The placeholder to be shown in the input field when the keyboard is active; 1-64 characters*/
 	InputFieldPlaceholder string `json:"input_field_placeholder,omitempty"`
 	/*Optional. Use this parameter if you want to show the keyboard to specific users only. Targets: 1) users that are @mentioned in the text of the Message object; 2) if the bot's message is a reply (has reply_to_message_id), sender of the original message.


### PR DESCRIPTION
Changed one_tijme_keyboard to one_time_keyboard in a /objects and v2/objects